### PR TITLE
Update AutoPkgReviewAndRun.py for Python 3

### DIFF
--- a/AutoPkgReviewAndRun.py
+++ b/AutoPkgReviewAndRun.py
@@ -1,4 +1,4 @@
-#!/Library/AutoPkg/Python3/Python.framework/Versions/3.7/bin/python3.7 
+#!/Library/AutoPkg/Python3/Python.framework/Versions/Current/bin/python3 
 
 ### This script updates AutoPkg repos, verifies trust info (with prompt to update after review), and runs recipes in a recipe list
 
@@ -34,8 +34,8 @@ def main():
                 verify_result = out
             desired_result = recipe + ": OK"
             if desired_result not in verify_result:
-                print(verify_result)
-                confirmation = raw_input("Do you trust these changes? (y/n) ")
+                print(err)
+                confirmation = input("Do you trust these changes? (y/n) ")
                 if confirmation.lower().strip() in affirmative_responses:
                     print("Updating trust info for {}".format(recipe))
                     cmd = [ "/usr/local/bin/autopkg", "update-trust-info", recipe ]

--- a/AutoPkgReviewAndRun.py
+++ b/AutoPkgReviewAndRun.py
@@ -1,10 +1,13 @@
-#!/usr/bin/python
+#!/Library/AutoPkg/Python3/Python.framework/Versions/3.7/bin/python3.7 
+
+### This script updates AutoPkg repos, verifies trust info (with prompt to update after review), and runs recipes in a recipe list
 
 import os
 import subprocess
 
-# Where is the recipe list (one recipe per line) located? Below is just an example. Modify as needed.
-recipe_list='/Users/USERNAME/Library/Application Support/AutoPkgr/recipe_list.txt'
+# Where is the recipe list (one recipe per line) located?
+# Recipe list should be one recipe per line, separated by a carriage return ("\n")
+recipe_list='/Users/a/Library/AutoPkg/recipe_list.txt'
 
 # Acceptable affirmative responses
 affirmative_responses=["y", "yes", "sure", "definitely"]
@@ -13,36 +16,46 @@ def main():
     # Double-check the recipe list file exists
     if os.path.exists(recipe_list):
         # Update the repos
-        subprocess.call(["autopkg","repo-update","all"])
+        print("Updating recipe repos...")
+        subprocess.call([ "/usr/local/bin/autopkg", "repo-update", "all" ])
         # Create an empty dictionary of recipes that need to be verified
         # Put the recipes into a list
         recipes = [recipe.rstrip('\n') for recipe in open(recipe_list)]
         # Loop through the recipes and see which ones need to be verified
         for recipe in recipes:
-            print "Verifying trust info for %s" % recipe
-            desired_result=recipe + ": OK"
+            print("Verifying trust info for {}".format(recipe))
             # See what the verified trust info looks like
-            p = subprocess.Popen(["autopkg", "verify-trust-info", "-vv", recipe],stdout=subprocess.PIPE,stderr=subprocess.PIPE)
-            verify_result,output_error = p.communicate()
-            if desired_result in verify_result:
-                print verify_result
+            cmd = [ "/usr/local/bin/autopkg", "verify-trust-info", "-vv", recipe ]
+            p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding='utf8')
+            out, err = p.communicate()
+            if err:
+                verify_result = "Verification failure"
             else:
-                print output_error
-                confirmation=raw_input("Do you trust these changes? (y/n) ")
+                verify_result = out
+            desired_result = recipe + ": OK"
+            if desired_result not in verify_result:
+                print(verify_result)
+                confirmation = raw_input("Do you trust these changes? (y/n) ")
                 if confirmation.lower().strip() in affirmative_responses:
-                    print "Updating trust info for %s" % recipe
-                    subprocess.call(["autopkg", "update-trust-info", recipe])
+                    print("Updating trust info for {}".format(recipe))
+                    cmd = [ "/usr/local/bin/autopkg", "update-trust-info", recipe ]
+                    p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding='utf8')
+                    out, err = p.communicate()
+                    if err:
+                        print("Unable to update trust info: {}".format(err))
                 else:
-                    print "Okay. Not updating trust for %s" % recipe
+                    print("Okay. Not updating trust for {}".format(recipe))
                     # Remove it from the list of recipes to run... no point in running it if the trust info isn't good
                     recipes.remove(recipe)
+            else:
+                print(verify_result)
         # Whether there were things to verify or not, go ahead and run the recipes
-        cmd = [ "autopkg", "run" ]
+        print("Running recipes...")
+        cmd = [ "/usr/local/bin/autopkg", "run" ]
         cmd.extend(recipes)
         subprocess.call(cmd)
-
     else:
-        print "%s does not exist. Aborting run." % recipe_list
+        print("{} does not exist. Aborting run.".format(recipe_list))
 
 if __name__ == "__main__":
     main()

--- a/AutoPkgReviewAndRun.py
+++ b/AutoPkgReviewAndRun.py
@@ -7,7 +7,7 @@ import subprocess
 
 # Where is the recipe list (one recipe per line) located?
 # Recipe list should be one recipe per line, separated by a carriage return ("\n")
-recipe_list='/Users/a/Library/AutoPkg/recipe_list.txt'
+recipe_list=os.path.expanduser('~/Library/AutoPkg/recipe_list.txt')
 
 # Acceptable affirmative responses
 affirmative_responses=["y", "yes", "sure", "definitely"]


### PR DESCRIPTION
Essentially the same workflow as before, just updated for Python 3.

Uses the Python 3 from AutoPkg 2 itself, so you have to have AutoPkg version 2 or higher installed.