### PR TITLE
Allow AutoPkgReviewAndRun.py to only verify, to only run, and to specify a recipe list location

### DIFF
--- a/AutoPkgReviewAndRun.py
+++ b/AutoPkgReviewAndRun.py
@@ -113,7 +113,13 @@ def run_recipes(recipes):
 
 def main():
     # Get arguments
-    recipeverify, reciperun, recipelist = get_options(recipe_list)
+    try:
+        recipeverify, reciperun, recipelist = get_options(recipe_list)
+    except:
+        print("No arguments. Running with defaults...")
+        recipelist = recipe_list
+        recipeverify = True
+        reciperun = True
 
     # Get recipe list
     recipes = get_recipe_list(recipelist)

--- a/AutoPkgReviewAndRun.py
+++ b/AutoPkgReviewAndRun.py
@@ -2,6 +2,7 @@
 
 ### This script updates AutoPkg repos, verifies trust info (with prompt to update after review), and runs recipes in a recipe list
 
+import argparse
 import os
 import subprocess
 import sys
@@ -12,6 +13,31 @@ recipe_list=os.path.expanduser('~/Library/AutoPkg/recipe_list.txt')
 
 # Acceptable affirmative responses
 affirmative_responses=["y", "yes", "sure", "definitely"]
+
+def get_options(recipe_list):
+    parser = argparse.ArgumentParser(description="Verifies and runs recipes in ~/Library/AutoPkg/recipe_list.txt")
+    parser.add_argument('--verifyonly', help="Only verify the recipes. Don't run AutoPkg.")
+    parser.add_argument('--runonly', help="Only run the recipe list. Do not verify trust info.", action='store_true')
+    parser.add_argument('--recipelist', help="Path to recipe list file. If not specified, the default location of ~/Library/AutoPkg/recipe_list.txt will be used instead")
+    args = parser.parse_args()
+    # If it's verify only, don't run
+    if args.verifyonly:
+        recipe_verify = True
+        recipe_run = False
+    # If it's run only, don't verify
+    elif args.runonly:
+        recipe_verify = False
+        recipe_run = True
+    # If it's neither verify only or run only, do both
+    else
+        recipe_verify = True
+        recipe_run = True
+    # See if there's a recipe list specified
+    if args.recipelist:
+        recipe_list = args.recipelist
+    else:
+        recipe_list = recipe_list
+    return recipe_verify, recipe_run, recipe_list
 
 def get_recipe_list(recipe_list):
     # Double-check the recipe list file exists
@@ -72,12 +98,17 @@ def run_recipes(recipes):
             sys.exit(1)
 
 def main():
-        # Get recipe list
-        get_recipe_list(recipe_list)
+    # Get arguments
+    recipe_verify, recipe_run, recipe_list = get_options(recipe_list)
 
+    # Get recipe list
+    get_recipe_list(recipe_list)
+
+    if recipeverify:
         # Get verified recipes
         recipes = verify_recipes(recipes, affirmative_responses)
 
+    if reciperun:
         # Run the recipes
         run_recipes(recipes)
 

--- a/AutoPkgReviewAndRun.py
+++ b/AutoPkgReviewAndRun.py
@@ -22,7 +22,7 @@ def get_options(recipe_list):
         action="store_true")
     parser.add_argument('--runonly', help="Only run the recipe list. Do not verify trust \
         info.", action="store_true")
-    parser.add_argument('--recipelist', help="Path to recipe list file. If not specified, \
+    parser.add_argument('-l', '--recipe-list', help="Path to recipe list file. If not specified, \
         the default location of ~/Library/AutoPkg/recipe_list.txt will be used instead")
     args = parser.parse_args()
     # If it's verify only, don't run
@@ -38,8 +38,10 @@ def get_options(recipe_list):
         recipeverify = True
         reciperun = True
     # See if there's a recipe list specified
-    if args.recipelist:
-        recipelist = args.recipelist
+    if args.recipe_list:
+        recipelist = args.recipe_list
+    elif args.l:
+        recipelist = args.l
     else:
         recipelist = recipe_list
     return recipeverify, reciperun, recipelist

--- a/AutoPkgReviewAndRun.py
+++ b/AutoPkgReviewAndRun.py
@@ -18,7 +18,7 @@ affirmative_responses = ["y", "yes", "sure", "definitely"]
 def get_options(recipe_list):
     parser = argparse.ArgumentParser(description="Verifies and runs recipes in \
         ~/Library/AutoPkg/recipe_list.txt")
-    parser.add_argument('--verifyonly', help="Only verify the recipes. Don't run AutoPkg.",
+    parser.add_argument('--verifyonly', help="Only verify the recipes. Do not run AutoPkg.",
         action="store_true")
     parser.add_argument('--runonly', help="Only run the recipe list. Do not verify trust \
         info.", action="store_true")

--- a/AutoPkgReviewAndRun.py
+++ b/AutoPkgReviewAndRun.py
@@ -102,7 +102,7 @@ def main():
     recipeverify, reciperun, recipelist = get_options(recipe_list)
 
     # Get recipe list
-    get_recipe_list(recipelist)
+    recipes = get_recipe_list(recipelist)
 
     if recipeverify:
         # Get verified recipes

--- a/AutoPkgReviewAndRun.py
+++ b/AutoPkgReviewAndRun.py
@@ -41,7 +41,7 @@ def get_options(recipe_list):
 
 def get_recipe_list(recipe_list):
     # Double-check the recipe list file exists
-    if os.path.exists(recipe_list):
+    if os.path.isfile(recipe_list):
         # Put the recipes into a list
         try:
             recipes = [recipe.rstrip('\n') for recipe in open(recipe_list)]

--- a/AutoPkgReviewAndRun.py
+++ b/AutoPkgReviewAndRun.py
@@ -25,8 +25,12 @@ def get_options(recipe_list):
     parser.add_argument('-l', '--recipe-list', help="Path to recipe list file. If not specified, \
         the default location of ~/Library/AutoPkg/recipe_list.txt will be used instead")
     args = parser.parse_args()
+    # If it's verify only and run only, give an error message
+    if args.verifyonly and args.runonly:
+        print("The verify only and run only options are mutually exclusive.")
+        sys.exit(1)
     # If it's verify only, don't run
-    if args.verifyonly:
+    elif args.verifyonly:
         recipeverify = True
         reciperun = False
     # If it's run only, don't verify

--- a/AutoPkgReviewAndRun.py
+++ b/AutoPkgReviewAndRun.py
@@ -16,8 +16,8 @@ affirmative_responses = ["y", "yes", "sure", "definitely"]
 
 def get_options(recipe_list):
     parser = argparse.ArgumentParser(description="Verifies and runs recipes in ~/Library/AutoPkg/recipe_list.txt")
-    parser.add_argument('--verifyonly', help="Only verify the recipes. Don't run AutoPkg.")
-    parser.add_argument('--runonly', help="Only run the recipe list. Do not verify trust info.", action='store_true')
+    parser.add_argument('--verifyonly', help="Only verify the recipes. Don't run AutoPkg.", action="store_true")
+    parser.add_argument('--runonly', help="Only run the recipe list. Do not verify trust info.", action="store_true")
     parser.add_argument('--recipelist', help="Path to recipe list file. If not specified, the default location of ~/Library/AutoPkg/recipe_list.txt will be used instead")
     args = parser.parse_args()
     # If it's verify only, don't run

--- a/AutoPkgReviewAndRun.py
+++ b/AutoPkgReviewAndRun.py
@@ -29,7 +29,7 @@ def get_options(recipe_list):
         recipe_verify = False
         recipe_run = True
     # If it's neither verify only or run only, do both
-    else
+    else:
         recipe_verify = True
         recipe_run = True
     # See if there's a recipe list specified

--- a/AutoPkgReviewAndRun.py
+++ b/AutoPkgReviewAndRun.py
@@ -4,6 +4,7 @@
 
 import os
 import subprocess
+import sys
 
 # Where is the recipe list (one recipe per line) located?
 # Recipe list should be one recipe per line, separated by a carriage return ("\n")
@@ -12,50 +13,73 @@ recipe_list=os.path.expanduser('~/Library/AutoPkg/recipe_list.txt')
 # Acceptable affirmative responses
 affirmative_responses=["y", "yes", "sure", "definitely"]
 
-def main():
+def get_recipe_list(recipe_list):
     # Double-check the recipe list file exists
     if os.path.exists(recipe_list):
-        # Update the repos
-        print("Updating recipe repos...")
-        subprocess.call([ "/usr/local/bin/autopkg", "repo-update", "all" ])
-        # Create an empty dictionary of recipes that need to be verified
         # Put the recipes into a list
-        recipes = [recipe.rstrip('\n') for recipe in open(recipe_list)]
-        # Loop through the recipes and see which ones need to be verified
-        for recipe in recipes:
-            print("Verifying trust info for {}".format(recipe))
-            # See what the verified trust info looks like
-            cmd = [ "/usr/local/bin/autopkg", "verify-trust-info", "-vv", recipe ]
-            p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding='utf8')
-            out, err = p.communicate()
-            if err:
-                verify_result = "Verification failure"
+        try:
+            recipes = [recipe.rstrip('\n') for recipe in open(recipe_list)]
+        except:
+            print("Unable to get recipe list {} into a list. Aborting run.".format(recipe_list))
+            sys.exit(1)
+        return recipes
+    else:
+        print("{} does not exist. Aborting run.".format(recipe_list))
+        sys.exit(1)
+
+def verify_recipes(recipes, affirmative_responses):
+    # Update the repos
+    print("Updating recipe repos...")
+    subprocess.call([ "/usr/local/bin/autopkg", "repo-update", "all" ])
+    # Loop through the recipes and see which ones need to be verified
+    for recipe in recipes:
+        print("Verifying trust info for {}".format(recipe))
+        # See what the verified trust info looks like
+        cmd = [ "/usr/local/bin/autopkg", "verify-trust-info", "-vv", recipe ]
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding='utf8')
+        out, err = p.communicate()
+        if err:
+            verify_result = "Verification failure"
+        else:
+            verify_result = out
+        desired_result = recipe + ": OK"
+        if desired_result not in verify_result:
+            print(err)
+            confirmation = input("Do you trust these changes? (y/n) ")
+            if confirmation.lower().strip() in affirmative_responses:
+                print("Updating trust info for {}".format(recipe))
+                cmd = [ "/usr/local/bin/autopkg", "update-trust-info", recipe ]
+                p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding='utf8')
+                out, err = p.communicate()
+                if err:
+                    print("Unable to update trust info: {}".format(err))
             else:
-                verify_result = out
-            desired_result = recipe + ": OK"
-            if desired_result not in verify_result:
-                print(err)
-                confirmation = input("Do you trust these changes? (y/n) ")
-                if confirmation.lower().strip() in affirmative_responses:
-                    print("Updating trust info for {}".format(recipe))
-                    cmd = [ "/usr/local/bin/autopkg", "update-trust-info", recipe ]
-                    p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding='utf8')
-                    out, err = p.communicate()
-                    if err:
-                        print("Unable to update trust info: {}".format(err))
-                else:
-                    print("Okay. Not updating trust for {}".format(recipe))
-                    # Remove it from the list of recipes to run... no point in running it if the trust info isn't good
-                    recipes.remove(recipe)
-            else:
-                print(verify_result)
-        # Whether there were things to verify or not, go ahead and run the recipes
+                print("Okay. Not updating trust for {}".format(recipe))
+                # Remove it from the list of recipes to run... no point in running it if the trust info isn't good
+                recipes.remove(recipe)
+        else:
+            print(verify_result)
+    return recipes
+
+def run_recipes(recipes):
         print("Running recipes...")
         cmd = [ "/usr/local/bin/autopkg", "run" ]
         cmd.extend(recipes)
-        subprocess.call(cmd)
-    else:
-        print("{} does not exist. Aborting run.".format(recipe_list))
+        try:
+            subprocess.call(cmd)
+        except:
+            print("Unable to run recipes. Aborting run.")
+            sys.exit(1)
+
+def main():
+        # Get recipe list
+        get_recipe_list(recipe_list)
+
+        # Get verified recipes
+        recipes = verify_recipes(recipes, affirmative_responses)
+
+        # Run the recipes
+        run_recipes(recipes)
 
 if __name__ == "__main__":
     main()

--- a/AutoPkgReviewAndRun.py
+++ b/AutoPkgReviewAndRun.py
@@ -9,10 +9,10 @@ import sys
 
 # Where is the recipe list (one recipe per line) located?
 # Recipe list should be one recipe per line, separated by a carriage return ("\n")
-recipe_list=os.path.expanduser('~/Library/AutoPkg/recipe_list.txt')
+recipe_list = os.path.expanduser('~/Library/AutoPkg/recipe_list.txt')
 
 # Acceptable affirmative responses
-affirmative_responses=["y", "yes", "sure", "definitely"]
+affirmative_responses = ["y", "yes", "sure", "definitely"]
 
 def get_options(recipe_list):
     parser = argparse.ArgumentParser(description="Verifies and runs recipes in ~/Library/AutoPkg/recipe_list.txt")

--- a/AutoPkgReviewAndRun.py
+++ b/AutoPkgReviewAndRun.py
@@ -1,6 +1,7 @@
 #!/Library/AutoPkg/Python3/Python.framework/Versions/Current/bin/python3 
 
-### This script updates AutoPkg repos, verifies trust info (with prompt to update after review), and runs recipes in a recipe list
+### This script updates AutoPkg repos, verifies trust info (with prompt to update after 
+### review), and runs recipes in a recipe list
 
 import argparse
 import os

--- a/AutoPkgReviewAndRun.py
+++ b/AutoPkgReviewAndRun.py
@@ -22,22 +22,22 @@ def get_options(recipe_list):
     args = parser.parse_args()
     # If it's verify only, don't run
     if args.verifyonly:
-        recipe_verify = True
-        recipe_run = False
+        recipeverify = True
+        reciperun = False
     # If it's run only, don't verify
     elif args.runonly:
-        recipe_verify = False
-        recipe_run = True
+        recipeverify = False
+        reciperun = True
     # If it's neither verify only or run only, do both
     else:
-        recipe_verify = True
-        recipe_run = True
+        recipeverify = True
+        reciperun = True
     # See if there's a recipe list specified
     if args.recipelist:
-        recipe_list = args.recipelist
+        recipelist = args.recipelist
     else:
-        recipe_list = recipe_list
-    return recipe_verify, recipe_run, recipe_list
+        recipelist = recipe_list
+    return recipeverify, reciperun, recipelist
 
 def get_recipe_list(recipe_list):
     # Double-check the recipe list file exists
@@ -99,10 +99,10 @@ def run_recipes(recipes):
 
 def main():
     # Get arguments
-    recipe_verify, recipe_run, recipe_list = get_options(recipe_list)
+    recipeverify, reciperun, recipelist = get_options(recipe_list)
 
     # Get recipe list
-    get_recipe_list(recipe_list)
+    get_recipe_list(recipelist)
 
     if recipeverify:
         # Get verified recipes

--- a/AutoPkgReviewAndRun.py
+++ b/AutoPkgReviewAndRun.py
@@ -15,10 +15,14 @@ recipe_list = os.path.expanduser('~/Library/AutoPkg/recipe_list.txt')
 affirmative_responses = ["y", "yes", "sure", "definitely"]
 
 def get_options(recipe_list):
-    parser = argparse.ArgumentParser(description="Verifies and runs recipes in ~/Library/AutoPkg/recipe_list.txt")
-    parser.add_argument('--verifyonly', help="Only verify the recipes. Don't run AutoPkg.", action="store_true")
-    parser.add_argument('--runonly', help="Only run the recipe list. Do not verify trust info.", action="store_true")
-    parser.add_argument('--recipelist', help="Path to recipe list file. If not specified, the default location of ~/Library/AutoPkg/recipe_list.txt will be used instead")
+    parser = argparse.ArgumentParser(description="Verifies and runs recipes in \
+        ~/Library/AutoPkg/recipe_list.txt")
+    parser.add_argument('--verifyonly', help="Only verify the recipes. Don't run AutoPkg.",
+        action="store_true")
+    parser.add_argument('--runonly', help="Only run the recipe list. Do not verify trust \
+        info.", action="store_true")
+    parser.add_argument('--recipelist', help="Path to recipe list file. If not specified, \
+        the default location of ~/Library/AutoPkg/recipe_list.txt will be used instead")
     args = parser.parse_args()
     # If it's verify only, don't run
     if args.verifyonly:
@@ -62,7 +66,8 @@ def verify_recipes(recipes, affirmative_responses):
         print("Verifying trust info for {}".format(recipe))
         # See what the verified trust info looks like
         cmd = [ "/usr/local/bin/autopkg", "verify-trust-info", "-vv", recipe ]
-        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding='utf8')
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            encoding='utf8')
         out, err = p.communicate()
         if err:
             verify_result = "Verification failure"
@@ -75,13 +80,15 @@ def verify_recipes(recipes, affirmative_responses):
             if confirmation.lower().strip() in affirmative_responses:
                 print("Updating trust info for {}".format(recipe))
                 cmd = [ "/usr/local/bin/autopkg", "update-trust-info", recipe ]
-                p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding='utf8')
+                p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                    encoding='utf8')
                 out, err = p.communicate()
                 if err:
                     print("Unable to update trust info: {}".format(err))
             else:
                 print("Okay. Not updating trust for {}".format(recipe))
-                # Remove it from the list of recipes to run... no point in running it if the trust info isn't good
+                # Remove it from the list of recipes to run... no point in running it if
+                # the trust info isn't good
                 recipes.remove(recipe)
         else:
             print(verify_result)

--- a/AutoPkgReviewAndRun.py
+++ b/AutoPkgReviewAndRun.py
@@ -22,7 +22,7 @@ def get_options(recipe_list):
         action="store_true")
     parser.add_argument('--runonly', help="Only run the recipe list. Do not verify trust \
         info.", action="store_true")
-    parser.add_argument('-l', '--recipe-list', help="Path to recipe list file. If not specified, \
+    parser.add_argument('--recipe-list', '-l', help="Path to recipe list file. If not specified, \
         the default location of ~/Library/AutoPkg/recipe_list.txt will be used instead")
     args = parser.parse_args()
     # If it's verify only and run only, give an error message
@@ -44,8 +44,6 @@ def get_options(recipe_list):
     # See if there's a recipe list specified
     if args.recipe_list:
         recipelist = args.recipe_list
-    elif args.l:
-        recipelist = args.l
     else:
         recipelist = recipe_list
     return recipeverify, reciperun, recipelist
@@ -113,13 +111,7 @@ def run_recipes(recipes):
 
 def main():
     # Get arguments
-    try:
-        recipeverify, reciperun, recipelist = get_options(recipe_list)
-    except:
-        print("No arguments. Running with defaults...")
-        recipelist = recipe_list
-        recipeverify = True
-        reciperun = True
+    recipeverify, reciperun, recipelist = get_options(recipe_list)
 
     # Get recipe list
     recipes = get_recipe_list(recipelist)


### PR DESCRIPTION
### Change summary
The original version of this just did everything—assumed a recipe list location that was hard-coded, updated all the recipe repos, verified all the recipes, and then ran the recipes in the recipe list.

### Major changes in this PR
- You can now verify only, run only, and specify a different recipe list location (if you don't like `~/Library/AutoPkg/recipe_list.txt`).
- There is additional error checking (using `try` and `except` as well as an exit code of `1`).

## Usage notes
`--runonly` will run the recipes in the recipe list and not verify trust info.
`--verifyonly` will verify the recipes in the recipe list and not run the recipes.
If you use both `--verifyonly` and `--runonly`, you'll get an error message. If you want to both verify and run, then just omit both parameters.
You can use either `--verifyonly` or `--runonly` in combination with `--recipe-list` or `-l`.
You can also use neither of those options and use only `--recipe-list` or `-l` by itself.